### PR TITLE
Update chai_http.md - add how to use chai-http with import -  issue #205

### DIFF
--- a/plugins/chai_http.md
+++ b/plugins/chai_http.md
@@ -32,6 +32,14 @@ var chai = require('chai')
 chai.use(chaiHttp);
 ```
 
+To use Chai HTTP with import
+```js
+import * as chai from 'chai';
+import chaiHttp from 'chai-http';
+chai.use(chaiHttp);
+```
+
+
 To use Chai HTTP on a web page, just include the [`dist/chai-http.js`](dist/chai-http.js) file:
 
 ```html


### PR DESCRIPTION
Update chai_http.md

add a new sample on how to use chai-http with `import`

thanks to @MIrinkov via [his comment](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19480#issuecomment-403374577)

This is part of #205